### PR TITLE
ユーザ名チェック処理を追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -29,23 +29,24 @@ service cloud.firestore {
         && data.updated != null
         ;
     }
-    function isOwner() {
-    	return request.auth.uid == resource.data.userId;
+    function isOwner(uid, name) {
+    	return get(/databases/$(database)/documents/userIds/$(uid)).data.name == name;
     }
     function isOwnerAndValidPost(data) {
     	return isOwner() && isValidPost(data);
     }
+
     match /users/{userName} {
     	allow read: if true;
       allow create: if request.auth.uid != null;
       match /posts/{postId} {
         allow read: if true;
         // TODO: temporary hotfix
-        allow create: if true //request.auth.uid == userId
+        allow create: if isOwner(request.auth.uid, userName)
         	&& isValidUserPost(request.resource.data);
-        allow update: if request.auth.uid == userId
+        allow update: if isOwner(request.auth.uid, userName)
         	&& isValidUserPost(request.resource.data);
-        allow delete: if request.auth.uid == userId;
+        allow delete: if isOwner(request.auth.uid, userName);
       }
     }
     match /allPosts/{post} {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -91,6 +91,18 @@ async function updateToAllPost(change: functions.Change<FirebaseFirestore.Docume
 	}
 }
 
+async function copyToUserToUserIds(snapshot: FirebaseFirestore.DocumentSnapshot, context: functions.EventContext) {
+	const user = snapshot.data() as UserData;
+	try {
+		const userIdData = {
+			name: user.name
+		};
+		return await firestore.collection("userIds").doc(user.id).set(userIdData);
+	} catch (error) {
+		return Promise.reject(error);
+	}
+}
 
 export const onUserPostCreate = functions.firestore.document("/users/{userName}/posts/{postId}").onCreate(copyToAllPost);
-functions.firestore.document("/users/{userName}/posts/{postId}").onUpdate(updateToAllPost);
+export const onUserPostUpdate = functions.firestore.document("/users/{userName}/posts/{postId}").onUpdate(updateToAllPost);
+export const onUserCreate = functions.firestore.document("/users/{userName}").onCreate(copyToUserToUserIds);


### PR DESCRIPTION
## このPRの要旨

- コレクションには `/users/${name}` を使いたい
- `name` は `request.auth.uid` ではない
- `request.auth.uid` 同様、 `request.auth.session.uesrName` みたいなものが使えればそのやり方はなさそう？
- 仕方ないのでusers作成時にuserIdsにコピーを作成し、 `get(userIds/$(request.auth.uid)` をした上でユーザ名認証をかけた

